### PR TITLE
Add gnome 48 to metadata

### DIFF
--- a/src/metadata.json
+++ b/src/metadata.json
@@ -7,6 +7,6 @@
      "kofi": "alexandervanhee"
   },
   "shell-version": [
-    "49","50"
+    "48","49","50"
   ]
 }


### PR DESCRIPTION
My distro is still on Gnome 48, just tested and it seems to work fine for me, might give better reach to add the version here? Didn't do a careful vet of what changed in the extension interface between 48 and 49, feel free to poke me to add compatibility patches if it's not this simple (never worked with extensions before).

Nice work!
