### PR TITLE
Fix (#26) out of order number stamp counter

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -45,6 +45,15 @@ function getToolDef(id) {
     return TOOLS.find(t => t.id === id) ?? null;
 }
 
+function resolveStampCounters(strokes) {
+    let stampCounter = 1;
+
+    return strokes.map(stroke => ({
+        ...stroke,
+        counter: stroke.toolId === 'stamp' ? stampCounter++ : stroke.counter,
+    }));
+}
+
 const DrawingCanvas = GObject.registerClass(
     class DrawingCanvas extends St.DrawingArea {
         _init(params) {
@@ -312,9 +321,7 @@ const DrawingCanvas = GObject.registerClass(
             if (this._currentStroke)
                 allStrokes.push(this._currentStroke);
 
-            let stampCounter = 1;
-
-            for (const stroke of allStrokes) {
+            for (const stroke of resolveStampCounters(allStrokes)) {
                 const tool = getToolDef(stroke.toolId);
                 if (!tool?.render)
                     continue;
@@ -326,7 +333,7 @@ const DrawingCanvas = GObject.registerClass(
                 tool.render(cr, {
                     color: stroke.color,
                     points: localPoints,
-                    counter: stroke.toolId === 'stamp' ? stampCounter++ : stroke.counter,
+                    counter: stroke.counter,
                     text: stroke.text,
                 }, stroke.strokeWidth);
             }
@@ -974,7 +981,7 @@ export default class GradiaCompanion extends Extension {
         }
 
         const strokes = this._canvases.flatMap(c =>
-            c.strokes.map(s => ({
+            resolveStampCounters(c.strokes).map(s => ({
                 color: s.color,
                 toolId: s.toolId,
                 counter: s.counter,


### PR DESCRIPTION
This solves the problem related in the issue #26 

The problem was being caused by the usage of different sources of truth:
- During screenshot the extension was using repaint time renumbering
- During save the extension was using the stored counter and this one was not being updated the same way the other one was

My proposed fix:
- Shared counter resolver

The bug seems to have been added in [Fix stamps to work like in Gradia](https://github.com/AlexanderVanhee/gradia-capture/commit/f144a9ad88d22f575e2f338a72e0720d72fbf7ef)

Before: 
<img width="1492" height="466" alt="image" src="https://github.com/user-attachments/assets/1822a2d4-0c2e-438b-b552-59a6c5e07577" />

Now:
<img width="1407" height="501" alt="image" src="https://github.com/user-attachments/assets/faea8ac0-d13e-4974-85f8-2801a118d917" />
